### PR TITLE
Fixed missing prop InputLabelProps

### DIFF
--- a/src/components/CurrencyTextField/CurrencyTextField.js
+++ b/src/components/CurrencyTextField/CurrencyTextField.js
@@ -106,6 +106,7 @@ class CurrencyTextField extends React.Component {
       "size",
       "FormHelperTextProps",
       "placeholder",
+      "InputLabelProps",
     ].forEach(prop => (otherProps[prop] = this.props[prop]))
 
     return (


### PR DESCRIPTION
This fix is to allow the customization of the input's label.