### PR TITLE
Deleting unused prop "rowsMax"

### DIFF
--- a/src/components/CurrencyTextField/CurrencyTextField.js
+++ b/src/components/CurrencyTextField/CurrencyTextField.js
@@ -95,7 +95,6 @@ class CurrencyTextField extends React.Component {
       "tabIndex",
       "fullWidth",
       "rows",
-      "rowsMax",
       "select",
       "required",
       "helperText",


### PR DESCRIPTION
Deleting unused prop "rowsMax" that is causing the following warning:

react-dom.development.js:67 Warning: React does not recognize the `rowsMax` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `rowsmax` instead. If you accidentally passed it from a parent component, remove it from the DOM element.